### PR TITLE
#167137428 Add regenerator runtime import to workers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ sequelize.sync().then(() => {
   cron.schedule('*/59 * * * *', () => {
     purgeWorker();
   });
-  cron.schedule('*/10 * * * *', () => {
+  cron.schedule('*/5 * * * *', () => {
     sendMailWorker();
   });
   app.listen(port, () => {

--- a/src/workers/purgeDeadTokens.js
+++ b/src/workers/purgeDeadTokens.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import 'regenerator-runtime';
 import Sequelize from 'sequelize';
 import db from '../sequelize/models';
 

--- a/src/workers/queueEmail.js
+++ b/src/workers/queueEmail.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import 'regenerator-runtime';
 import models from '../sequelize/models';
 
 const { Emails } = models;

--- a/src/workers/sendMail.js
+++ b/src/workers/sendMail.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import 'regenerator-runtime';
 import { forEach } from 'lodash';
 import models from '../sequelize/models';
 import sendMail from '../helpers/mailer/SendAnyEmail';

--- a/src/workers/uploadImage.js
+++ b/src/workers/uploadImage.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import 'regenerator-runtime';
 import { v2 as cloudinary } from 'cloudinary';
 import dotenv from 'dotenv';
 import models from '../sequelize/models';


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the bug where workers were failing on Heroku due to missing `regenerator-runtime` imports

#### Description of Task to be completed?
- add `regenerator-runtime` imports to workers
- reduce email sending cronjob interval from 10 to 5 minutes

#### How should this be manually tested?
The server should run on Heroku without displaying error logs when the workers are running

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#166978153 #167137428 

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A